### PR TITLE
Add better support for newlines and make test output cleaner

### DIFF
--- a/src/parser.mly
+++ b/src/parser.mly
@@ -1,4 +1,4 @@
-%{ open Ast %}
+%{ %}
 
 /* Boolean operators */
 %token NOT OR AND
@@ -50,6 +50,7 @@ program_without_eof:
   program_without_eof stmt {}
 | program_without_eof fdecl {}
 | program_without_eof classdecl {}
+| program_without_eof NEWLINE {}
 | /* nothing */ {}
 
 optional_fdecls:

--- a/src/scanner.mll
+++ b/src/scanner.mll
@@ -72,7 +72,7 @@ rule tokenize = parse
 | ':' { COLON }
 | '.' { PERIOD }
 | ',' { COMMA }
-| '\n' { NEWLINE }
+| ['\n']+ { NEWLINE }
 | "NULL" { NULL }
 (* User defined types, i.e. class names *)
 | class_name as t { TYPE(t) }


### PR DESCRIPTION
- Fixes #32 by having the scanner collapse multiple consecutive newlines into a single newline and also allowing a program to be only newlines
- Fixes #8 by adding some more tests. Calling "make test" will now no longer print a bunch of junk to the screen, and will instead just show the real Python unit test results.
- Fixes a compile warning that we weren't using Ast inside parser.mly