### PR TITLE
Add proper syntax for objects and self keyword

### DIFF
--- a/src/parser.mly
+++ b/src/parser.mly
@@ -112,16 +112,23 @@ assigns:
 
 assign:
   TYPE IDENTIFIER EQ expr {}
+| object_variable_access EQ expr {}
 
 func_call:
   IDENTIFIER PERIOD IDENTIFIER LPAREN params RPAREN {}
+| SELF PERIOD IDENTIFIER LPAREN params RPAREN {}
 | IDENTIFIER LPAREN params RPAREN {}
 | IDENTIFIER PERIOD IDENTIFIER LPAREN RPAREN {}
+| SELF PERIOD IDENTIFIER LPAREN RPAREN {}
 | IDENTIFIER LPAREN RPAREN {}
 
 object_instantiation:
   TYPE LPAREN params RPAREN {}
 | TYPE LPAREN RPAREN {}
+
+object_variable_access:
+  IDENTIFIER PERIOD IDENTIFIER {}
+| SELF PERIOD IDENTIFIER {}
 
 array_access:
   IDENTIFIER LBRACKET expr RBRACKET {}
@@ -140,6 +147,7 @@ expr:
 | NULL {}
 | func_call {}
 | object_instantiation {}
+| object_variable_access {}
 | array_access {}
 | array_literal {}
 | LPAREN expr RPAREN {}

--- a/src/run_tests.py
+++ b/src/run_tests.py
@@ -34,7 +34,7 @@ class TestLexerAndParser(unittest.TestCase):
 
   def assertPassed(self, stdout, stderr):
     self.assertIn(_PASSED, stdout)
-    self.assertEqual(b"", stderr)
+    self.assertNotIn(b"Stdlib.Parsing.Parse_error", stderr)
 
   def assertFailed(self, stdout, stderr):
     self.assertEqual(b"", stdout)
@@ -143,6 +143,38 @@ class TestLexerAndParser(unittest.TestCase):
     program = b"int x = 5 \n\n\n\n"
     self.assertProgramPasses(program)
 
+  def test_self_access_with_field(self):
+    program = b"self.x\n"
+    self.assertProgramPasses(program)
+
+  def test_self_assignment_with_field(self):
+    program = b"self.x = 5\n"
+    self.assertProgramPasses(program)
+
+  def test_self_with_expression(self):
+    program = b"int x = self.foo * 5\n"
+    self.assertProgramPasses(program)
+
+  def test_self_access_with_function(self):
+    program = b"self.myfunction(2 % 3) \n"
+    self.assertProgramPasses(program)
+
+  def test_object_variable_access(self):
+    program = b"myobject.x \n"
+    self.assertProgramPasses(program)
+
+  def test_object_variable_assignment(self):
+    program = b"myobject.fOOo12345 = true\n"
+    self.assertProgramPasses(program)
+
+  def test_object_variable_with_expression(self):
+    program = b"boolean x = true and myobject.is_this_true\n"
+    self.assertProgramPasses(program)
+
+  def test_object_function_call(self):
+    program = b"myobject.myfunction(a, b, c)\n\n"
+    self.assertProgramPasses(program)
+
   def test_nonsense_fails(self):
     program = b"%-$_? !?\n"
     self.assertProgramFails(program)
@@ -193,6 +225,14 @@ class TestLexerAndParser(unittest.TestCase):
 
   def test_invalid_newlines(self):
     program = b"\n = x\n"
+    self.assertProgramFails(program)
+
+  def test_invalid_self_usage(self):
+    program = b"self.\n"
+    self.assertProgramFails(program)
+
+  def test_invalid_object_usage(self):
+    program = b"myobject.\n"
     self.assertProgramFails(program)
 
 

--- a/src/scanner.mll
+++ b/src/scanner.mll
@@ -61,7 +61,6 @@ rule tokenize = parse
 | "false" { BOOLEAN_LITERAL(false) }
 (* TODO strings and chars *)
 (* TODO syntactically meaningful whitespace - must keep track of INDENT *)
-(* TODO comments, single-line and multi-line *)
 | '#'  { single_comment lexbuf }
 | "/#" { multi_comment lexbuf }
 (* Misc. punctuation *)
@@ -85,7 +84,7 @@ rule tokenize = parse
 (* If we see a lowercase letter followed by any letters or digits,
    it could either be the name of a primitive type (e.g. int), or
    a reserved word (e.g. class) or an identifier for a variable. *)
-| ['a'-'z']['a'-'z' 'A'-'Z' '0'-'9']* as possible_id {
+| ['a'-'z']['a'-'z' 'A'-'Z' '0'-'9' '_']* as possible_id {
     if List.mem possible_id primitive_types
       then TYPE(possible_id)
     else if StringMap.mem possible_id reserved_word_to_token


### PR DESCRIPTION
- Fixes #27 
- Made the unit tests more robust so that they will pass regardless of whether OCAMLRUNPARAM='p' is set or not
- Allow identifiers to have underscores in them as long as the underscore is not the first char. This allows us to use snake_case